### PR TITLE
Profile picture gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,12 +30,14 @@ __pycache__/
 *.pyd
 .Python
 env/
+.env
 .venv/
 activate/
 ENV/
 env.bak/
 venv.bak/
 backend/globals.py
+venv/
 
 
 # IDE-specific ignores (add or remove based on your IDE)

--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,11 @@
 /audio/*
 /recordings/*
 /logs/*
-/dist/*
 /backend/build/*
 /backend/dist/*
 /frontend/dist/*
 /tests/*
-.env
+*dist
 
 # If you want to ensure that the directories themselves are kept (but empty), you can add a .gitkeep file in each.
 # Uncomment the lines below if you are using .gitkeep files to keep empty directories in your repository
@@ -63,4 +62,3 @@ venv/
 # Ignore package-lock.json
 *package-lock.json
 *node_modules
-*dist

--- a/frontend/src/components/ProfilePicture.jsx
+++ b/frontend/src/components/ProfilePicture.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Camera } from 'lucide-react';
+
+const API_BASE_URL = 'http://localhost:5001';
+
+function ProfilePicture() {
+    // Initialize as null (we don't know if the user has a pic yet)
+    const [profilePic, setProfilePic] = useState(null);
+    // New state to track if the image is actually loading successfully
+    const [imageLoaded, setImageLoaded] = useState(false);
+    const fileInputRef = useRef(null);
+
+    // Fetch the S3 URL when the component first loads
+    useEffect(() => {
+        fetch(`${API_BASE_URL}/api/profile-pic`)
+            .then(res => res.json())
+            .then(data => {
+                if (data.url) {
+                    setProfilePic(data.url);
+                    // Don't set imageLoaded true yet, wait for the onLoad event
+                }
+            })
+            .catch(err => console.error("Error fetching profile pic:", err));
+    }, []);
+
+    const handleProfilePicClick = () => {
+        fileInputRef.current.click();
+    };
+
+    const handleFileChange = async (event) => {
+        const file = event.target.files[0];
+        if (!file) return;
+
+        // Reset load status while uploading
+        setImageLoaded(false);
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        try {
+            console.log("Uploading...");
+            const response = await fetch(`${API_BASE_URL}/api/upload-profile-pic`, {
+                method: 'POST',
+                body: formData
+            });
+            
+            const data = await response.json();
+
+            if (response.ok && data.url) {
+                console.log("Upload success, new URL:", data.url);
+                // Append a timestamp to force the browser to treat it as a new image
+                const timestampedUrl = `${data.url}${data.url.includes('?') ? '&' : '?'}t=${Date.now()}`;
+                setProfilePic(timestampedUrl);
+            } else {
+                console.error("Failed to upload profile picture:", data.error);
+            }
+        } catch (error) {
+            console.error("Error uploading profile picture:", error);
+        }
+    };
+
+    return (
+        <div className="flex flex-col items-center p-6 pb-8">
+            <div 
+                onClick={handleProfilePicClick}
+                className="relative w-32 h-32 bg-blue-100 rounded-full border border-teal-500 mb-6 cursor-pointer overflow-hidden group"
+            >
+                {/* FIX: We now always render the img tag if a URL exists.
+                   We use CSS to hide it until it successfully loads.
+                */}
+                {profilePic && (
+                    <img
+                        src={profilePic}
+                        alt="Profile"
+                        className={`w-full h-full object-cover rounded-full ${imageLoaded ? 'block' : 'hidden'}`}
+                        onLoad={() => {
+                            console.log("Profile picture loaded successfully!");
+                            setImageLoaded(true);
+                        }}
+                        onError={(e) => { 
+                            console.log("Image failed to load (S3 might be slow), hiding it temporarily.");
+                            setImageLoaded(false);
+                        }}
+                    />
+                )}
+
+                {/* Placeholder: Only show if we have no URL OR if the image hasn't loaded yet */}
+                {(!profilePic || !imageLoaded) && (
+                    <div className="absolute inset-0 flex items-center justify-center text-teal-500 font-bold bg-blue-100 rounded-full">
+                        User
+                    </div>
+                )}
+                
+                {/* Hover Overlay */}
+                <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center opacity-0 group-hover:opacity-60 transition-opacity rounded-full">
+                    <Camera className="text-white" size={24} />
+                </div>
+            </div>
+
+            <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                onChange={handleFileChange}
+                style={{ display: 'none' }}
+            />
+        </div>
+    );
+}
+
+export default ProfilePicture;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Home, Gamepad2, FolderOpen, Edit, BarChart2 } from 'lucide-react';
+import ProfilePicture from './ProfilePicture';
 const { ipcRenderer } = window.require('electron');
 
 function Sidebar() {
     const location = useLocation();
-
+    
     const isActive = (path) => {
         return location.pathname === path;
     };
@@ -13,9 +14,7 @@ function Sidebar() {
     return (
         <div className="w-64 bg-white border-r border-teal-500 text-gray-700 flex flex-col h-full">
             {/* User profile */}
-            <div className="flex flex-col items-center p-6 pb-8">
-                <div className="w-32 h-32 bg-blue-100 rounded-full border border-teal-500 mb-6"></div>
-            </div>
+            <ProfilePicture />
 
             {/* Navigation links */}
             <nav className="flex-grow">

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "axios": "^1.8.1",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.2.0"
     }
 }


### PR DESCRIPTION
Profile Picture Implementation!
- Currently only accepts png, jpg, jpeg, and gif
- Uploads and retrieves straight from S3 so might have to be careful of AWS costs (or not?)

I'm not sure how it will work when the multiple usernames get implemented but for now, if the pull request is accepted, we should all be sharing the same profile picture. (Fun!)

Details:

Backend:
- New directory in app.py
- Two new api endpoints to handle uploading and retrieving profile pictures from S3
- Implementation of the actual functionality

Frontend:
- New ProfilePicture.jsx component will replace the placeholder div in SideBar.jsx, making it support profile picture functions.

Misc:
- .gitignore now also ignores venv/ and .env

<img width="100" height="300" alt="image" src="https://github.com/user-attachments/assets/6f606af1-2152-4417-b635-3a13d21a710f" />


