### PR TITLE
Fix media files not loading

### DIFF
--- a/backend/window/app.py
+++ b/backend/window/app.py
@@ -40,7 +40,7 @@ except ImportError as e:
             return self
 
         def get_presigned_url(self, file_path):
-            object_name = f"sophia/{os.path.basename(file_path)}"
+            object_name = f"{os.getenv('USERNAME')}/{os.path.basename(file_path)}"
             url = self.client.generate_presigned_url(
                 'put_object',
                 Params={'Bucket': self.bucket_name, 'Key': object_name},

--- a/frontend/src/components/HeroImage.jsx
+++ b/frontend/src/components/HeroImage.jsx
@@ -49,7 +49,7 @@ function HeroImage({ onImageChange }) {
         try {
             setLoadingAllScreenshots(true);
             console.log('Fetching all screenshots...');
-            const response = await fetch('/api/media_aws');
+            const response = await fetch(`/api/media_aws?username=${encodeURIComponent(currentUsername)}`);
             if (!response.ok) {
                 throw new Error('Failed to fetch screenshots');
             }

--- a/frontend/src/pages/FilesPage.jsx
+++ b/frontend/src/pages/FilesPage.jsx
@@ -115,7 +115,7 @@ function FilesPage() {
                 .map(u => u.username);
 
             if (userList.length === 0) {
-                const resp = await fetch('/api/media_aws', { signal });
+                const resp = await fetch(`/api/media_aws?username=${encodeURIComponent(currentUsername)}`, { signal });
                 if (!resp.ok) throw new Error('Failed to fetch media');
                 const data = await resp.json();
                 setMediaList(data);

--- a/frontend/src/pages/GamesPage.jsx
+++ b/frontend/src/pages/GamesPage.jsx
@@ -18,7 +18,7 @@ function GamesPage() {
   const fetchMediaData = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/media_aws');
+      const response = await fetch(`/api/media_aws?username=${encodeURIComponent(currentUsername)}`);
       if (!response.ok) {
         throw new Error('Failed to fetch media');
       }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -60,7 +60,7 @@ function HomePage() {
     const fetchGameSessions = async () => {
         try {
             setLoadingTimeline(true);
-            const response = await fetch('/api/media_aws');
+            const response = await fetch(`/api/media_aws?username=${encodeURIComponent(currentUsername)}`);
             const mediaData = await response.json();
 
             // Group media by game_id and get the latest timestamp for each game

--- a/frontend/src/pages/StatsPage.jsx
+++ b/frontend/src/pages/StatsPage.jsx
@@ -1,8 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { BarChart2 } from 'lucide-react';
 import Timeline from '../components/Timeline';
+import { UserContext } from '../context/UserContext.jsx';
 
 function StatsPage() {
+    const user = useContext(UserContext);
+    const currentUsername = user?.username || 'User';
+
     const [mediaStats, setMediaStats] = useState({
         screenshots: 0,
         videos: 0,
@@ -13,14 +17,16 @@ function StatsPage() {
     const [loadingTimeline, setLoadingTimeline] = useState(true);
 
     useEffect(() => {
-        fetchMediaStats();
-        fetchGameSessions();
-    }, []);
+        if (currentUsername !== 'User') {
+            fetchMediaStats();
+            fetchGameSessions();
+        }
+    }, [currentUsername]); 
 
     const fetchMediaStats = async () => {
         try {
             setLoadingStats(true);
-            const response = await fetch('/api/media_aws');
+            const response = await fetch(`/api/media_aws?username=${encodeURIComponent(currentUsername)}`);
             const mediaData = await response.json();
 
             const stats = mediaData.reduce((acc, item) => {
@@ -41,10 +47,9 @@ function StatsPage() {
     const fetchGameSessions = async () => {
         try {
             setLoadingTimeline(true);
-            const response = await fetch('/api/media_aws');
+            const response = await fetch(`/api/media_aws?username=${encodeURIComponent(currentUsername)}`);
             const mediaData = await response.json();
 
-            // Group media by game_id and get the latest timestamp for each game
             const gameSessions = mediaData.reduce((acc, item) => {
                 if (!item.game_id) return acc;
 
@@ -62,7 +67,6 @@ function StatsPage() {
                 return acc;
             }, {});
 
-            // Convert to array and sort by timestamp
             const timeline = Object.values(gameSessions)
                 .sort((a, b) => b.timestamp - a.timestamp);
 
@@ -74,7 +78,6 @@ function StatsPage() {
         }
     };
 
-    // Render the stats summary
     const renderStatsSummary = () => {
         if (loadingStats) {
             return (
@@ -92,7 +95,7 @@ function StatsPage() {
         return (
             <div className="bg-white rounded-lg border border-gray-200 p-6 mb-8">
                 <div className="mb-4">
-                    <h2 className="text-xl font-semibold text-gray-700">Media Statistics</h2>
+                    <h2 className="text-xl font-semibold text-gray-700">Media Statistics for {currentUsername}</h2>
                 </div>
                 <div className="grid grid-cols-3 gap-6">
                     <div className="bg-blue-50 rounded-lg p-4 text-center">
@@ -120,7 +123,6 @@ function StatsPage() {
 
             {renderStatsSummary()}
 
-            {/* Timeline Section */}
             <div className="max-w-7xl mx-auto px-4 py-8">
                 <h2 className="text-2xl font-bold text-teal-700 mb-6">Recent Activity</h2>
                 {loadingTimeline ? (


### PR DESCRIPTION
Fixed by suffixing most calls to media_aws with the current username.

Note there are still a few bugs associated with this:
- The stats page doesn't call media_aws with the username because for some reason it breaks everything. For me, the regular call is still working on the stats page. This should probably be investigated more at some point, though.
- If the app starts before the server, the username doesn't load because the call to the server fails. This causes all the calls to media_aws to fail, but can be fixed by refreshing the page with ctrl+r